### PR TITLE
feat(select): proof of concept

### DIFF
--- a/packages/match-components/package.json
+++ b/packages/match-components/package.json
@@ -67,6 +67,7 @@
     "@types/styled-system__theme-get": "5.0.1",
     "core-js": "3.8.3",
     "csstype": "3.0.6",
+    "downshift": "6.1.0",
     "jest": "26.6.3",
     "jest-axe": "4.1.0",
     "prop-types": "15.7.2",

--- a/packages/match-components/src/index.ts
+++ b/packages/match-components/src/index.ts
@@ -6,6 +6,7 @@ export * from "./grid";
 export * from "./heading";
 export * from "./input";
 export * from "./paragraph";
+export * from "./select";
 export * from "./separator";
 export * from "./snippet";
 export * from "./truncate";

--- a/packages/match-components/src/select/index.ts
+++ b/packages/match-components/src/select/index.ts
@@ -1,0 +1,3 @@
+export * from "./select";
+export * from "./option";
+export * from "./types";

--- a/packages/match-components/src/select/option.tsx
+++ b/packages/match-components/src/select/option.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import { StyledOption } from "./styles";
+import type { OptionProps } from "./types";
+
+export const Option = React.forwardRef<HTMLLIElement, OptionProps>(
+  (props, ref) => <StyledOption ref={ref} {...props} />
+);
+
+Option.displayName = "Option";
+
+Option.propTypes = {
+  value: PropTypes.string.isRequired,
+  highlighted: PropTypes.bool,
+  selected: PropTypes.bool,
+};

--- a/packages/match-components/src/select/select.tsx
+++ b/packages/match-components/src/select/select.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import { useCombobox } from "downshift";
+import { StyledCombobox, StyledSelect, StyledListbox } from "./styles";
+import type { SelectProps, OptionProps } from "./types";
+
+type Items = Array<React.ReactElement<OptionProps>>;
+
+export const Select = React.forwardRef<HTMLInputElement, SelectProps>(
+  ({ children, label, name }, ref) => {
+    const [items, setItems] = React.useState(
+      React.Children.toArray(children) as Items
+    );
+
+    const {
+      isOpen,
+      openMenu,
+      getLabelProps,
+      getToggleButtonProps,
+      getMenuProps,
+      getInputProps,
+      getComboboxProps,
+      highlightedIndex,
+      selectedItem,
+      getItemProps,
+    } = useCombobox({
+      items: items.map((child) => child.props.value),
+      onInputValueChange: ({ type, inputValue }) => {
+        const allItems = React.Children.toArray(children) as Items;
+        if (!inputValue || type !== useCombobox.stateChangeTypes.InputChange) {
+          setItems(allItems);
+        } else {
+          setItems(
+            allItems.filter((item) =>
+              item.props.value
+                .toLowerCase()
+                .startsWith(inputValue.toLowerCase())
+            )
+          );
+        }
+      },
+    });
+
+    return (
+      <StyledSelect>
+        <label {...getLabelProps()}>{label}</label>
+        <StyledCombobox {...getComboboxProps()}>
+          <input
+            ref={ref}
+            {...getInputProps({
+              name,
+              placeholder: "Select One",
+              onClick: () => openMenu(),
+            })}
+          />
+          <button type="button" {...getToggleButtonProps()}>
+            <span role="img" aria-label="dropdown">
+              👇🏾
+            </span>
+          </button>
+        </StyledCombobox>
+        <StyledListbox {...getMenuProps()}>
+          {isOpen &&
+            items.map((child, index) =>
+              React.cloneElement(child, {
+                selected: Boolean(child.props.value === selectedItem),
+                highlighted: Boolean(index === highlightedIndex),
+                key: child.key || child.props.value,
+                ...getItemProps({ item: child.props.value, index }),
+              })
+            )}
+        </StyledListbox>
+      </StyledSelect>
+    );
+  }
+);
+
+Select.displayName = "Select";
+
+Select.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  children: (props, propName, componentName) => {
+    let error = null;
+    React.Children.forEach(props[propName], (child) => {
+      if (child.type.displayName !== "Option") {
+        error = new Error(
+          `[${componentName}]: invalid child element '${child.type.displayName}'`
+        );
+      }
+    });
+    return error;
+  },
+};

--- a/packages/match-components/src/select/styles.ts
+++ b/packages/match-components/src/select/styles.ts
@@ -1,0 +1,64 @@
+import styled, { css } from "styled-components";
+import type { OptionProps } from "./types";
+
+export const StyledOption = styled.li<OptionProps>`
+  padding: 5px;
+
+  ${({ highlighted }) =>
+    highlighted &&
+    css`
+      background: lightgray;
+    `}
+
+  ${({ selected }) =>
+    selected &&
+    css`
+      ::after {
+        content: " 👈🏽";
+      }
+    `}
+`;
+
+export const StyledCombobox = styled.div`
+  position: relative;
+
+  input {
+    width: 100%;
+    padding: 10px;
+    border: 2px solid gray;
+
+    :focus {
+      border: 2px solid blue;
+      outline: none;
+    }
+  }
+
+  button {
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    padding: 2px;
+    background: none;
+    border: none;
+    transform: translateY(-50%);
+    cursor: pointer;
+  }
+`;
+
+export const StyledListbox = styled.ul`
+  position: absolute;
+  right: 0;
+  bottom: -3px;
+  left: 0;
+  max-height: 50vh;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+  transform: translateY(100%);
+`;
+
+export const StyledSelect = styled.div`
+  position: relative;
+`;

--- a/packages/match-components/src/select/types.ts
+++ b/packages/match-components/src/select/types.ts
@@ -1,0 +1,12 @@
+export interface OptionProps extends React.LiHTMLAttributes<HTMLLIElement> {
+  value: string;
+  highlighted?: boolean;
+  selected?: boolean;
+}
+
+export interface SelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  name: string;
+  label: string;
+  children: Array<React.ReactElement<OptionProps>>;
+}

--- a/packages/match-components/stories/select.stories.tsx
+++ b/packages/match-components/stories/select.stories.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { Story, Meta } from "@storybook/react/types-6-0";
+import { Select, Option } from "../src";
+
+export default {
+  title: "Components/Select",
+  component: Select,
+  args: {},
+  argTypes: {},
+} as Meta;
+
+// const Template: Story<SelectProps> = (args) => <Select {...args} />;
+
+export const Primary: Story = () => {
+  const characters = [
+    "Abracadaniel",
+    "Ancient Sleeping Magi of Life Giving",
+    "Banana Man",
+    "Betty Grof",
+    "Billy",
+    "Boy Bear",
+    "Bronwyn",
+    "Bufo",
+    "Charlie",
+    "Chet",
+    "Chocoberry",
+    "Choose Goose",
+    "Cinnamon Bun",
+    "Cosmic Owl",
+    "Crunchy/Chicle",
+    "Cuber",
+    "Death",
+    "Dr. Ice Cream",
+    "Elise",
+    "Fern",
+    "Flambo",
+    "Flame King",
+    "Football",
+    "Forest Wizard",
+  ];
+  return (
+    <div style={{ maxWidth: "300px" }}>
+      <Select name="character" label="Choose your character">
+        {characters.map((character) => (
+          <Option key={character} value={character}>
+            {character}
+          </Option>
+        ))}
+      </Select>
+    </div>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4120,6 +4120,7 @@ __metadata:
     "@types/styled-system__theme-get": 5.0.1
     core-js: 3.8.3
     csstype: 3.0.6
+    downshift: 6.1.0
     jest: 26.6.3
     jest-axe: 4.1.0
     prop-types: 15.7.2
@@ -10011,7 +10012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"downshift@npm:^6.0.6":
+"downshift@npm:6.1.0, downshift@npm:^6.0.6":
   version: 6.1.0
   resolution: "downshift@npm:6.1.0"
   dependencies:


### PR DESCRIPTION
1. yarn
2. yarn start:storybook
3. Check out the new Select component 😎 

I evaluated using `react-select` and rolling our own component with `downshift`. react-select is pretty good, but seems difficult to customize. Also it has a dependency on emotion, so we'd be loading two styling libraries 😬 

Downshift essentially handles all the accessibility labeling and keyboard navigation for you and not much else. This proof of concept definitely needs a lot more considerations. For instance... What happens if you open it when the select is near the bottom of the screen? react-select scrolls the screen for you, but I'm not sure I like hijacking the window scroll.