### PR TITLE
feat(Anchor): optional href w/ button fallback

### DIFF
--- a/packages/match-components/__tests__/anchor.test.tsx
+++ b/packages/match-components/__tests__/anchor.test.tsx
@@ -9,7 +9,7 @@ import { Anchor } from "../src";
 
 const AnchorWithTheme = withTheme()(Anchor);
 
-describe("Button", () => {
+describe("Anchor", () => {
   test("renders external anchor", () => {
     render(
       <AnchorWithTheme href="https://twilio.com">Click Me</AnchorWithTheme>
@@ -48,6 +48,13 @@ describe("Button", () => {
     expect(screen.getByText(/click me/i).getAttribute("rel")).toEqual(
       "noopener"
     );
+  });
+
+  test("renders as a button", () => {
+    render(<AnchorWithTheme>I am a button</AnchorWithTheme>);
+    expect(
+      screen.getByText(/i am a button/i).tagName.toLocaleLowerCase()
+    ).toEqual("button");
   });
 
   test("accessibility violations", async () => {

--- a/packages/match-components/package.json
+++ b/packages/match-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/match-components",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Twilio Match Design System Components",
   "author": "Twilio Inc.",
   "license": "Apache-2.0",

--- a/packages/match-components/src/anchor/anchor.tsx
+++ b/packages/match-components/src/anchor/anchor.tsx
@@ -12,8 +12,7 @@ const EXTERNAL_URL_REGEX = /^(https?:)\S*$/;
 const secureExternalLink = (
   href?: string
 ): Record<string, unknown> | undefined => {
-  if (!href) return {};
-  if (EXTERNAL_URL_REGEX.test(href)) {
+  if (href && EXTERNAL_URL_REGEX.test(href)) {
     return { rel: "noreferrer noopener", target: "_blank" };
   }
 };

--- a/packages/match-components/src/anchor/anchor.tsx
+++ b/packages/match-components/src/anchor/anchor.tsx
@@ -10,8 +10,9 @@ import type { AnchorProps } from "./types";
 const EXTERNAL_URL_REGEX = /^(https?:)\S*$/;
 
 const secureExternalLink = (
-  href: string
+  href?: string
 ): Record<string, unknown> | undefined => {
+  if (!href) return {};
   if (EXTERNAL_URL_REGEX.test(href)) {
     return { rel: "noreferrer noopener", target: "_blank" };
   }
@@ -20,7 +21,12 @@ const secureExternalLink = (
 export const Anchor = React.forwardRef<HTMLAnchorElement, AnchorProps>(
   ({ children, icon: Icon, ...props }, ref) => {
     return (
-      <StyledAnchor ref={ref} {...secureExternalLink(props.href)} {...props}>
+      <StyledAnchor
+        as={Boolean(props.href) ? "a" : "button"}
+        ref={ref}
+        {...secureExternalLink(props.href)}
+        {...props}
+      >
         {children}
         {Icon && (
           <Icon
@@ -43,7 +49,7 @@ Anchor.propTypes = {
   icon: PropTypes.func,
   children: PropTypes.node.isRequired,
   variant: PropTypes.oneOf(Object.values(AnchorVariant)),
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
   target: PropTypes.oneOf(Object.values(AnchorTarget)),
   rel: PropTypes.string,
   noUnderline: PropTypes.bool,

--- a/packages/match-components/src/anchor/styles.ts
+++ b/packages/match-components/src/anchor/styles.ts
@@ -5,7 +5,12 @@ import { AnchorVariant } from "./constants";
 import type { AnchorProps } from "./types";
 
 export const StyledAnchor = styled.a<AnchorProps>`
+  padding: 0;
+  font-size: inherit;
+  font-family: inherit;
   text-decoration: underline;
+  background: none;
+  border: none;
   cursor: pointer;
 
   &:focus {

--- a/packages/match-components/src/anchor/types.ts
+++ b/packages/match-components/src/anchor/types.ts
@@ -9,7 +9,7 @@ export interface AnchorProps
   variant?: `${AnchorVariant}`;
   icon?: IconComponentProp;
   /** A URL to route to. */
-  href: string;
+  href?: string;
   /** Defaults to '_blank' for external links */
   target?: `${AnchorTarget}`;
   /** Defaults to 'noreferrer noopener' for external links  */

--- a/packages/match-components/stories/anchor.stories.tsx
+++ b/packages/match-components/stories/anchor.stories.tsx
@@ -11,7 +11,6 @@ export default {
   args: {
     children: "Ahoy",
     noUnderline: false,
-    href: "/flex",
   },
   argTypes: {
     children: { table: { disable: true } },
@@ -31,11 +30,13 @@ const Template: Story<AnchorProps> = (args) => <Anchor {...args} />;
 export const Primary = Template.bind({});
 Primary.args = {
   variant: AnchorVariant.PRIMARY,
+  href: "/flex",
 };
 
 export const Inverse = Template.bind({});
 Inverse.args = {
   variant: AnchorVariant.INVERSE,
+  href: "/flex",
 };
 Inverse.parameters = {
   backgrounds: { default: "Darkest" },
@@ -44,6 +45,7 @@ Inverse.parameters = {
 export const Text = Template.bind({});
 Text.args = {
   variant: AnchorVariant.TEXT,
+  href: "/flex",
 };
 
 export const External = Template.bind({});
@@ -53,15 +55,22 @@ External.args = {
   children: "Default for an External Link in Text Variant",
 };
 
+export const Button = Template.bind({});
+Button.args = {
+  variant: AnchorVariant.PRIMARY,
+};
+
 export const PrimaryIcon = Template.bind({});
 PrimaryIcon.args = {
   icon: OutboundIcon,
+  href: "/flex",
 };
 
 export const InverseIcon = Template.bind({});
 InverseIcon.args = {
   variant: AnchorVariant.INVERSE,
   icon: OutboundIcon,
+  href: "/flex",
 };
 InverseIcon.parameters = {
   backgrounds: { default: "Darkest" },
@@ -71,4 +80,5 @@ export const TextIcon = Template.bind({});
 TextIcon.args = {
   variant: AnchorVariant.TEXT,
   icon: OutboundIcon,
+  href: "/flex",
 };

--- a/packages/match/package.json
+++ b/packages/match/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/match",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Twilio Match Design System",
   "author": "Twilio Inc.",
   "license": "Apache-2.0",

--- a/website/src/docs/components/anchor.mdx
+++ b/website/src/docs/components/anchor.mdx
@@ -23,7 +23,7 @@ const Component = () => <Anchor href="/">Ahoy</Anchor>;
 | Prop         | Type          | Default   | Description                              |
 | ------------ | ------------- | --------- | ---------------------------------------- |
 | variant?     | AnchorVariant | 'primary' | 'primary', 'inverse', 'text'             |
-| href         | string        | null      | A URL to route to.                       |
+| href?        | string        | null      | A URL to route to.                       |
 | target?      | AnchorTarget  | null      | '\_self', '\_blank', '\_parent', '\_top' |
 | rel?         | string        | null      | Defaults to '\_blank' for external links |
 | noUnderline? | boolean       | false     | Removes the underline from the anchor.   |
@@ -35,12 +35,14 @@ const Component = () => <Anchor href="/">Ahoy</Anchor>;
 ### Anchors vs Buttons
 
 All actions outside of linking to another URL should use a button. For example, actions such as submitting a form or closing a module should
-use a button.
+use a Button.
 
-The button component can also be used as a CTA anchor when the href prop is included. In this situation the element looks like a button but
+If an Anchor does not link to a valid URL, omit the `href` attribute to render as a button. Never set `href` to "#" or "javascript:void(0)".
+
+The Button component can also be used as a CTA anchor when the href prop is included. In this situation the element looks like a button but
 renders as an anchor.
 
-Learn more about the [button component](/docs/components/button) to determine if it will fit your needs better.
+Learn more about the [Button component](/docs/components/button) to determine if it will fit your needs better.
 
 ### Accessibility
 


### PR DESCRIPTION
I’m seeing a need for a button component that looks like an anchor. It’s not good practice to make psuedo buttons like `<a href="javascript:void(0)">` or `<a href="#">`. Those should be buttons with click handlers. This PR makes `href` optional for the Anchor element. When href is not provided, the component renders as a button.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
